### PR TITLE
Fix README terminal formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,29 +16,44 @@ The interaction model is designed to be unobtrusive, similar to activating a Pyt
 
 ### **Core Workflow**
 
-1. **Activate a Session:** You begin by starting a Robot-aware session. This command launches a new sub-shell where all input and output will be monitored.  
-   robot activate
+1. **Activate a Session:** You begin by starting a Robot-aware session. This command launches a new sub-shell where all input and output will be monitored.
 
-   Your terminal prompt will change slightly to indicate that you are in an active Robot session.  
-2. **Work as Usual:** Use the terminal as you normally would. Robot works in the background, logging your commands and their results.  
-   (robot) $ ls \-l  
-   total 8  
-   \-rw-r--r--  1 user  staff  1024 Jul 11 10:30 data.csv  
-   \-rwxr-xr--  1 user  staff  2560 Jul 11 10:32 process.sh
+```bash
+robot activate
+```
 
-   (robot) $ head \-n 2 data.csv  
-   id,value,timestamp  
-   1,42,2025-07-11T10:30:00Z
+Your terminal prompt will change slightly to indicate that you are in an active Robot session.
+2. **Work as Usual:** Use the terminal as you normally would. Robot works in the background, logging your commands and their results.
 
-3. **Ask a Question:** When you need help or information, use the robot command followed by your question in plain English.  
-   (robot) $ robot "Based on the files here, what is the purpose of the shell script?"
+```bash
+(robot) $ ls -l
+total 8
+-rw-r--r--  1 user  staff  1024 Jul 11 10:30 data.csv
+-rwxr-xr--  1 user  staff  2560 Jul 11 10:32 process.sh
 
-4. **Get an Answer:** Robot analyzes the recorded session context (the ls and head commands and their output) and provides a relevant answer.  
-   \> The script 'process.sh' likely processes the 'data.csv' file. The CSV file contains columns named 'id', 'value', and 'timestamp'.
+(robot) $ head -n 2 data.csv
+id,value,timestamp
+1,42,2025-07-11T10:30:00Z
+```
 
-5. **Deactivate the Session:** When you're done, you can exit the session and return to your normal shell.  
-   (robot) $ exit  
-   $
+3. **Ask a Question:** When you need help or information, use the robot command followed by your question in plain English.
+
+```bash
+(robot) $ robot "Based on the files here, what is the purpose of the shell script?"
+```
+
+4. **Get an Answer:** Robot analyzes the recorded session context (the ls and head commands and their output) and provides a relevant answer.
+
+```bash
+> The script 'process.sh' likely processes the 'data.csv' file. The CSV file contains columns named 'id', 'value', and 'timestamp'.
+```
+
+5. **Deactivate the Session:** When you're done, you can exit the session and return to your normal shell.
+
+```bash
+(robot) $ exit
+$
+```
 
 ## **4\. Technical Plan**
 
@@ -46,17 +61,17 @@ This project will be developed in Python, focusing on robust session management 
 
 ### **Core Components:**
 
-1. **Session Management (Pseudo-Terminal):**  
-   * The core of Robot's functionality will rely on Python's pty module. The robot activate command will spawn a new user shell (e.g., /bin/bash or /bin/zsh) as a child process running within a pseudo-terminal.  
+1. **Session Management (Pseudo-Terminal):**
+   * The core of Robot's functionality will rely on Python's pty module. The `robot activate` command will spawn a new user shell (e.g., /bin/bash or /bin/zsh) as a child process running within a pseudo-terminal.
    * The main Robot process will act as the master of the pty, allowing it to read all output from the shell (stdout) and write all input to it (stdin).  
 2. **Background Logging:**  
    * During an active session, all I/O passing through the pseudo-terminal will be captured and written to a temporary log file.  
    * This log will be a structured record of the entire terminal session, preserving the sequence of commands and their exact outputs, which is crucial for providing accurate context to the LLM.  
 3. **Command-Line Interface (CLI):**  
    * We will use **Typer** to build the CLI.  
-   * The primary commands will be:  
-     * robot activate: Starts the monitored session.  
-     * robot \<query\>: The command used within an active session to ask a question. This command will locate the session log, package it with the query, and send it to the LLM.  
+   * The primary commands will be:
+     * `robot activate`: Starts the monitored session.
+     * `robot <query>`: The command used within an active session to ask a question. This command will locate the session log, package it with the query, and send it to the LLM.
 4. **LLM Integration:**  
    * The robot \<query\> command will read the entire content of the current session's log file.  
    * This content will be formatted into a prompt for a large language model. The prompt will be engineered to instruct the LLM to act as a terminal assistant and answer the user's query based on the provided session transcript.  
@@ -66,10 +81,10 @@ This project will be developed in Python, focusing on robust session management 
 
 The project will be developed in distinct phases, starting with the most critical functionality.
 
-1. **Phase 1: Core Session Management**  
-   * \[ \] Implement the robot activate command to successfully launch a sub-shell within a pseudo-terminal using Python's pty module.  
+1. **Phase 1: Core Session Management**
+   * \[ \] Implement the `robot activate` command to successfully launch a sub-shell within a pseudo-terminal using Python's pty module.
    * \[ \] Develop the background logging mechanism to capture all session I/O to a temporary file.  
-   * \[ \] Create the basic robot \<query\> command that reads the log file and the user's query.  
+   * \[ \] Create the basic `robot <query>` command that reads the log file and the user's query.
    * \[ \] Integrate with a foundational LLM API to establish the proof-of-concept pipeline.  
 2. **Phase 2: Refinement and Usability**  
    * \[ \] Improve the prompt engineering to handle long session contexts and provide more accurate answers.  


### PR DESCRIPTION
## Summary
- show commands and output with terminal code blocks
- mark references to CLI commands with inline code

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68713de8a7ac8326acbbaff8e4d9dfb4