### PR TITLE
Implement basic session activation

### DIFF
--- a/src/robot/cli.py
+++ b/src/robot/cli.py
@@ -1,11 +1,14 @@
+import os
+import pty
 import typer
 
 app = typer.Typer(add_completion=False)
 
 @app.command()
 def activate() -> None:
-    """Start a monitored shell session (placeholder)."""
-    typer.echo("Activating robot session (not yet implemented).")
+    """Start a monitored shell session."""
+    shell = os.environ.get("SHELL", "/bin/bash")
+    pty.spawn(shell)
 
 @app.command(name="query")
 def query_command(question: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,3 +7,16 @@ def test_help():
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "activate" in result.stdout
+
+
+def test_activate_invokes_pty(monkeypatch):
+    called = []
+
+    def fake_spawn(cmd):
+        called.append(cmd)
+        return 0
+
+    monkeypatch.setattr("pty.spawn", fake_spawn)
+    result = runner.invoke(app, ["activate"])
+    assert result.exit_code == 0
+    assert called


### PR DESCRIPTION
## Summary
- implement `robot activate` using `pty.spawn`
- test CLI activation functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68714d3d34c88326a662c54d636b4523