### PR TITLE
Implement logging for activate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This project will be developed in Python, focusing on robust session management 
 The project will be developed in distinct phases, starting with the most critical functionality.
 
 1. **Phase 1: Core Session Management**
-   * \[ \] Implement the `robot activate` command to successfully launch a sub-shell within a pseudo-terminal using Python's pty module.
+   * \[x] Implement the `robot activate` command to successfully launch a sub-shell within a pseudo-terminal using Python's pty module.
    * \[ \] Develop the background logging mechanism to capture all session I/O to a temporary file.  
    * \[ \] Create the basic `robot <query>` command that reads the log file and the user's query.
    * \[ \] Integrate with a foundational LLM API to establish the proof-of-concept pipeline.  

--- a/src/robot/cli.py
+++ b/src/robot/cli.py
@@ -1,5 +1,6 @@
 import os
 import pty
+import tempfile
 import typer
 
 app = typer.Typer(add_completion=False)
@@ -8,7 +9,25 @@ app = typer.Typer(add_completion=False)
 def activate() -> None:
     """Start a monitored shell session."""
     shell = os.environ.get("SHELL", "/bin/bash")
-    pty.spawn(shell)
+    with tempfile.NamedTemporaryFile(prefix="robot-", suffix=".log", delete=False) as log_file:
+        typer.echo(f"Session log: {log_file.name}")
+        os.environ["ROBOT_SESSION_LOG"] = log_file.name
+
+        def master_read(fd: int) -> bytes:
+            data = os.read(fd, 1024)
+            if data:
+                log_file.write(data)
+                log_file.flush()
+            return data
+
+        def stdin_read(fd: int) -> bytes:
+            data = os.read(fd, 1024)
+            if data:
+                log_file.write(data)
+                log_file.flush()
+            return data
+
+        pty.spawn(shell, master_read=master_read, stdin_read=stdin_read)
 
 @app.command(name="query")
 def query_command(question: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import os
 from typer.testing import CliRunner
 from robot.cli import app
 
@@ -12,11 +13,15 @@ def test_help():
 def test_activate_invokes_pty(monkeypatch):
     called = []
 
-    def fake_spawn(cmd):
-        called.append(cmd)
+    def fake_spawn(cmd, **kwargs):
+        called.append(kwargs)
         return 0
 
     monkeypatch.setattr("pty.spawn", fake_spawn)
     result = runner.invoke(app, ["activate"])
     assert result.exit_code == 0
     assert called
+    assert "master_read" in called[0]
+    assert "stdin_read" in called[0]
+    log_path = result.stdout.split("Session log: ")[1].strip()
+    assert os.path.exists(log_path)


### PR DESCRIPTION
## Summary
- add session logging to `activate` command
- mark activate roadmap item as complete
- improve tests for new logging behavior

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68714fd4960483268ca659747ae2a850