### PR TITLE
Improve prompt engineering and update models

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This project will be developed in Python, focusing on robust session management 
    * The robot \<query\> command will read the entire content of the current session's log file.  
    * This content will be formatted into a prompt for a large language model. The prompt will be engineered to instruct the LLM to act as a terminal assistant and answer the user's query based on the provided session transcript.  
    * The response from the LLM will be printed directly to the terminal.
+   * Documentation consulted for model usage includes the [OpenAI Cookbook](https://cookbook.openai.com) and [Google AI for Developers](https://ai.google.dev).
 
 ## **5\. Project Roadmap**
 
@@ -87,8 +88,8 @@ The project will be developed in distinct phases, starting with the most critica
     * \[x] Develop the background logging mechanism to capture all session I/O to a temporary file.
     * \[x] Create the basic `robot <query>` command that reads the log file and the user's query.
    * \[ \] Integrate with a foundational LLM API to establish the proof-of-concept pipeline.  
-2. **Phase 2: Refinement and Usability**  
-   * \[ \] Improve the prompt engineering to handle long session contexts and provide more accurate answers.  
+2. **Phase 2: Refinement and Usability**
+   * \[x] Improve the prompt engineering to handle long session contexts and provide more accurate answers.
    * \[ \] Implement clean session start-up and tear-down, including handling of the session log files.  
    * \[ \] Add configuration options (e.g., choosing the LLM provider, setting API keys).  
    * \[ \] Refine the in-session prompt to provide clear feedback to the user.  

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,31 @@
+import types
+import sys
+import robot.llm as llm
+
+
+def test_long_session_truncated(monkeypatch):
+    captured = {}
+
+    class FakeMessage:
+        def __init__(self, content):
+            self.content = content
+
+    class FakeChoice:
+        def __init__(self, message):
+            self.message = message
+
+    class FakeChatCompletion:
+        def create(self, *, model, messages):
+            captured['model'] = model
+            captured['messages'] = messages
+            return types.SimpleNamespace(choices=[FakeChoice(FakeMessage("ok"))])
+
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    fake_openai = types.SimpleNamespace(ChatCompletion=FakeChatCompletion())
+    monkeypatch.setitem(sys.modules, 'openai', fake_openai)
+    long_session = "a" * (llm.MAX_SESSION_CHARS + 10)
+    llm.ask("q", long_session, provider="openai")
+    sent = captured['messages'][1]['content']
+    assert sent.startswith("Session:\n...")
+    assert sent.endswith("\n\nQuestion:\nq")
+    assert captured['model'] == "gpt-4.1-mini"


### PR DESCRIPTION
## Summary
- add `_build_messages` helper to truncate long session logs
- default to modern models: `gpt-4.1-mini` and `gemini-2.5-flash`
- mark Phase 2 prompt-engineering step as done and cite official docs
- test that long session logs are truncated before sending to the LLM

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875609c39588326a12a6d0c071b8703