### PR TITLE
Add query spinner

### DIFF
--- a/src/robot/cli.py
+++ b/src/robot/cli.py
@@ -6,6 +6,7 @@ import tempfile
 import typer
 
 from . import llm
+from rich.console import Console
 
 app = typer.Typer(add_completion=False)
 
@@ -64,9 +65,11 @@ def query_command(question: str) -> None:
     with open(log_path, "r") as f:
         session_data = f.read()
 
-    typer.echo(f"Query: {question}")
-    response = llm.ask(question, session_data)
-    typer.echo(response)
+    console = Console()
+    with console.status("", spinner="dots"):
+        response = llm.ask(question, session_data)
+
+    console.print(response)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,7 +43,7 @@ def test_query_reads_log(tmp_path, monkeypatch, capsys):
 
     main(["what", "is", "going", "on?"])
     out = capsys.readouterr().out
-    assert "Query: what is going on?" in out
+    assert "Query:" not in out
     assert called["question"] == "what is going on?"
     assert called["session"] == "command output"
     assert out.strip().endswith("answer")


### PR DESCRIPTION
## Summary
- remove 'Query:' echo in CLI
- show spinner while waiting for the LLM
- adapt tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877aa24ddf08326879bd5d323c3ba1b