### PR TITLE
Fix API key error handling

### DIFF
--- a/src/robot/cli.py
+++ b/src/robot/cli.py
@@ -67,7 +67,11 @@ def query_command(question: str) -> None:
 
     console = Console()
     with console.status("", spinner="dots"):
-        response = llm.ask(question, session_data)
+        try:
+            response = llm.ask(question, session_data)
+        except RuntimeError as e:
+            console.print(str(e))
+            raise typer.Exit(1)
 
     console.print(response)
 


### PR DESCRIPTION
## Summary
- gracefully handle missing API keys when querying
- test CLI behavior for missing API keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b021c7d48326975a239165bdd589